### PR TITLE
alternative main for Amazon Linux ami

### DIFF
--- a/roles/setup/tasks/main-yum.yml
+++ b/roles/setup/tasks/main-yum.yml
@@ -1,0 +1,43 @@
+---
+- name: "update yum packages."
+  become: true
+  yum:
+    update_cache: true
+
+- name: "upgrade packages"
+  become: true
+  yum:
+    name: "*"
+    state: latest
+
+- name: "install node dependencies"
+  become: true
+  yum:
+    name:
+      - nodejs
+      #- npm # TODO: additional steps required before installing this
+    state: present
+    update_cache: true
+
+- name: "install pm2"
+  become: true
+  npm:
+    name: pm2
+    global: true
+    production: true
+    state: present
+
+- name: "create ~/web"
+  ansible.builtin.file:
+    path: ~/web
+    state: directory
+    mode: '0755'
+
+- name: "copy files"
+  copy:
+    src: index.js
+    dest: ~/web
+    backup: true
+
+- name: "start server"
+  shell: pm2 start ~/web/index.js -f


### PR DESCRIPTION
Amazon Linux ami use `yum`. As the tutorial are shown mainly in Ubuntu (which use `apt`), this may be helpful because, I believe, some of us does not have permission in launching Ubuntu instance

<img width="680" alt="image" src="https://user-images.githubusercontent.com/10347427/170833885-5ba1dec6-34d2-4ee0-af73-b127a9995131.png">
